### PR TITLE
Add autolink detection. See RM #38031

### DIFF
--- a/src/autolink.js
+++ b/src/autolink.js
@@ -1,6 +1,6 @@
 function tryConvertAutolink(link) {
     // https://spec.commonmark.org/0.29/#absolute-uri
-    const uri = /^([a-zA-Z][a-zA-Z0-9+.-]{1,31}:[^\s\x00-\x1f<>]*)/
+    const uri = /^([a-zA-Z][a-zA-Z0-9+.-]{1,31}:[^\s\x00-\x1f<>\\]*)$/
 
     // https://spec.commonmark.org/0.29/#email-address
     const mail = /[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+(@)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(?![-_])/
@@ -9,4 +9,39 @@ function tryConvertAutolink(link) {
         return link 
     }
     return null
+}
+
+function tests() {
+    // From CommonMark's specs: https://spec.commonmark.org/0.29/#autolinks
+    const validAutolinks = [
+        'http://foo.bar.baz',
+        'http://foo.bar.baz/test?q=hello&id=22&boolean',
+        'irc://foo.bar:2233/baz',
+        'MAILTO:FOO@BAR.BAZ',
+
+        // technically not valid URIs but CommonMark permits them
+        'a+b+c:d',
+        'made-up-scheme://foo,bar',
+        'http://../',
+        'localhost:5001/foo',
+    ]
+
+    const invalidAutolinks = [
+        'http://foo.bar/baz bim',
+        'http://example.com/\\[\\'
+    ]
+
+    validAutolinks.forEach(link => {
+        if (tryConvertAutolink(link) !== link) {
+            throw `${link} was not converted to an autolink`
+        }
+    })
+
+    invalidAutolinks.forEach(link => {
+        if (tryConvertAutolink(link) !== null) {
+            throw `${link} was converted to an autolink`
+        }
+    })
+
+    console.log("All tests passed...")
 }

--- a/src/autolink.js
+++ b/src/autolink.js
@@ -3,7 +3,7 @@ function tryConvertAutolink(link) {
     const uri = /^([a-zA-Z][a-zA-Z0-9+.-]{1,31}:[^\s\x00-\x1f<>\\]*)$/
 
     // https://spec.commonmark.org/0.29/#email-address
-    const mail = /[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+(@)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(?![-_])/
+    const mail = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
 
     if (uri.test(link) || mail.test(link)) {
         return link 
@@ -24,11 +24,19 @@ function tests() {
         'made-up-scheme://foo,bar',
         'http://../',
         'localhost:5001/foo',
+
+        'foo@bar.example.com',
+        'foo+special@Bar.baz-bar0.com'
     ]
 
     const invalidAutolinks = [
         'http://foo.bar/baz bim',
-        'http://example.com/\\[\\'
+        'http://example.com/\\[\\',
+        'foo\\+@bar.example.com',
+        '<>',
+        ' http://foo.bar ',
+        'm:abc',
+        'foo.bar.baz'
     ]
 
     validAutolinks.forEach(link => {

--- a/src/autolink.js
+++ b/src/autolink.js
@@ -1,0 +1,12 @@
+function tryConvertAutolink(link) {
+    // https://spec.commonmark.org/0.29/#absolute-uri
+    const uri = /^([a-zA-Z][a-zA-Z0-9+.-]{1,31}:[^\s\x00-\x1f<>]*)/
+
+    // https://spec.commonmark.org/0.29/#email-address
+    const mail = /[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+(@)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(?![-_])/
+
+    if (uri.test(link) || mail.test(link)) {
+        return link 
+    }
+    return null
+}


### PR DESCRIPTION
Došel jsem k závěru, že nějaký escaping nejspíše nebude možný.

Pro URI je CommonMark specifikace velice laxní a povoluje i stringy, které nejsou validní URI:

Note that many strings that count as absolute URIs for purposes of this spec are not valid URIs, because their schemes are not registered or because of other problems with their syntax.

U emailových adres je situace trochu komplexnější - (specifikace)[https://spec.commonmark.org/0.29/#email-address] vyžaduje namatchování na "non-normative regex" pro emailové adresy z HTML5 Living Standard specifikace. Existuje tedy neprázdná množina emailových adres, které jsou validní podle (RFC 5322)[https://tools.ietf.org/html/rfc5322], ale výše uvedeným regexpem neprojdou. Nicméně, takové emailové adresy mají poněkud zvláštní formát a slušný člověk by si jich neměl všímat.

