### PR TITLE
Fix browser module export

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "module": "lib/turndown.es.js",
   "jsnext:main": "lib/turndown.es.js",
   "browser": {
-    "jsdom": false
+    "jsdom": false,
+    "./lib/turndown.cjs.js": "./lib/turndown.browser.cjs.js",
+    "./lib/turndown.es.js": "./lib/turndown.browser.es.js",
+    "./lib/turndown.umd.js": "./lib/turndown.browser.umd.js"
   },
   "dependencies": {
     "jsdom": "^16.2.0"


### PR DESCRIPTION
When users want to build their project, the output contains JSDOM even though the JSDOM dependency is turned off in `browser` attribute. It's caused by using default module (turndown.es.js) which contains JSDOM. At this moment there is no way to use `*.browser` module variants which don't contain JSDOM. This PR fixes `browser` attribute in package.json so the browser module can be exported.

Motivation behind this PR: 
I'm using Turndown as a dependency in another project and when I build `umd` package with Rollup.js, Turndown with JSDOM is included and there is no elegant way to replace it except modifying `browser` attribute. After that `rollup/plugin-node-resolve` can use the module exported by `browser` attribute when building my project.